### PR TITLE
fix missing Begin(TRI_QUADS) in full-screen HUD sprite rendering

### DIFF
--- a/nextclient/client_mini/src/hud/hud_sprite/hud_sprite.cpp
+++ b/nextclient/client_mini/src/hud/hud_sprite/hud_sprite.cpp
@@ -21,6 +21,7 @@ void HudSprite::Draw() const
     ta->Color4f(getColor().red, getColor().green, getColor().blue, getCurrentAlpha());
     ta->CullFace(TRI_NONE);
     if (isFullScreen()) {
+        ta->Begin(TRI_QUADS);
         ta->TexCoord2f(0, 0);
         ta->Vertex3f(0, 0, 0);
         ta->TexCoord2f(0, 1);


### PR DESCRIPTION
Full-screen HUD sprites didn't render because Begin() was missing